### PR TITLE
feat: enable optional self-signed TLS support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2
       - name: Set up Node 12
         uses: actions/setup-node@v1
         with:
@@ -19,6 +22,8 @@ jobs:
           java-version: 1.8
       - name: Build with Maven
         run: mvn -ntp -U clean verify
+        env:
+          AWS_REGION: us-west-2
       - name: Upload Failed Test Report
         uses: actions/upload-artifact@v1.0.0
         if: failure()

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,12 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.1.46.Final</version>
+            <version>4.1.59.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.68</version>
         </dependency>
         <dependency>
             <groupId>org.java-websocket</groupId>
@@ -195,6 +200,10 @@
                                 <relocation>
                                     <pattern>org.java_websocket</pattern>
                                     <shadedPattern>com.aws.greengrass.localdebugconsole.lib.org.java_websocket</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.bouncycastle</pattern>
+                                    <shadedPattern>com.aws.greengrass.localdebugconsole.lib.org.bouncycastle</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/src/main/java/com/aws/greengrass/localdebugconsole/GGSSLWebSocketServerFactory.java
+++ b/src/main/java/com/aws/greengrass/localdebugconsole/GGSSLWebSocketServerFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.localdebugconsole;
+
+import org.java_websocket.SSLSocketChannel2;
+import org.java_websocket.WebSocketAdapter;
+import org.java_websocket.WebSocketImpl;
+import org.java_websocket.WebSocketServerFactory;
+import org.java_websocket.drafts.Draft;
+import org.java_websocket.server.DefaultSSLWebSocketServerFactory;
+
+import java.io.IOException;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.inject.Provider;
+import javax.net.ssl.SSLEngine;
+
+/**
+ * This class is based on {@link DefaultSSLWebSocketServerFactory} but instead of accepting a {@link javax.net.ssl.SSLContext}
+ * it instead takes a provider of {@link SSLEngine}.
+ */
+public class GGSSLWebSocketServerFactory implements WebSocketServerFactory {
+    protected Provider<SSLEngine> engineProvider;
+    protected ExecutorService exec;
+
+    public GGSSLWebSocketServerFactory(Provider<SSLEngine> engineProvider) {
+        this(engineProvider, Executors.newSingleThreadScheduledExecutor());
+    }
+
+    public GGSSLWebSocketServerFactory(Provider<SSLEngine> engineProvider, ExecutorService exec) {
+        if (engineProvider != null && exec != null) {
+            this.engineProvider = engineProvider;
+            this.exec = exec;
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public ByteChannel wrapChannel(SocketChannel channel, SelectionKey key) throws IOException {
+        SSLEngine e = this.engineProvider.get();
+        List<String> ciphers = new ArrayList<>(Arrays.asList(e.getEnabledCipherSuites()));
+        ciphers.remove("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        e.setEnabledCipherSuites(ciphers.toArray(new String[0]));
+        e.setUseClientMode(false);
+        return new SSLSocketChannel2(channel, e, this.exec, key);
+    }
+
+    public WebSocketImpl createWebSocket(WebSocketAdapter a, Draft d) {
+        return new WebSocketImpl(a, d);
+    }
+
+    public WebSocketImpl createWebSocket(WebSocketAdapter a, List<Draft> d) {
+        return new WebSocketImpl(a, d);
+    }
+
+    public void close() {
+        this.exec.shutdownNow();
+    }
+}

--- a/src/main/js/dashboard-frontend/src/communication/ServerEndpoint.ts
+++ b/src/main/js/dashboard-frontend/src/communication/ServerEndpoint.ts
@@ -40,8 +40,9 @@ export default class ServerEndpoint {
     this.timeout = timeout;
 
     // declare connections
+    const proto = window.location.protocol === "https:" ? "wss" : "ws";
     this.conn = new WebSocket(
-      `ws://${window.location.hostname}:${this.portno}`
+      `${proto}://${window.location.hostname}:${this.portno}`
     );
     this.conn.onmessage = this.messageHandler;
 

--- a/src/test/java/com/aws/greengrass/localdebugconsole/DashboardServerTest.java
+++ b/src/test/java/com/aws/greengrass/localdebugconsole/DashboardServerTest.java
@@ -5,12 +5,12 @@
 
 package com.aws.greengrass.localdebugconsole;
 
+import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.localdebugconsole.dashboardtestmocks.DashboardClientMock;
 import com.aws.greengrass.localdebugconsole.messageutils.ComponentItem;
 import com.aws.greengrass.localdebugconsole.messageutils.DepGraphNode;
 import com.aws.greengrass.localdebugconsole.messageutils.Dependency;
 import com.aws.greengrass.localdebugconsole.messageutils.PackedRequest;
-import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.GreengrassLogMessage;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -37,8 +37,6 @@ import static com.aws.greengrass.localdebugconsole.DashboardServer.SERVER_START_
 import static com.aws.greengrass.logging.impl.Slf4jLogAdapter.addGlobalListener;
 import static com.aws.greengrass.logging.impl.Slf4jLogAdapter.removeGlobalListener;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,7 +76,7 @@ class DashboardServerTest {
 
         addGlobalListener(listener);
         ds = new DashboardServer(new InetSocketAddress("localhost", dashboardServerPort),
-                LogManager.getLogger(Kernel.class), kc, authenticator);
+                LogManager.getLogger(Kernel.class), kc, authenticator, null);
         ds.startup();
         assertTrue(startupLatch.await(5, TimeUnit.SECONDS));
         dashboardServerPort = ds.getPort();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding self-signed TLS support as optional (defaulting to on).

**Why is this change necessary:**
Increases security by encrypting the username/password tokens.

**How was this change tested:**
All existing tests are passing, manually verified that TLS is generating a 4096 bit certificate and serving it properly. Verified that the websocket is also using TLS. Added new test to validate that we can connect using TLS and validate the certificate provided.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
