### PR TITLE
fix: china region docs and dismiss flashbar items

### DIFF
--- a/src/main/java/com/aws/greengrass/localdebugconsole/SimpleHttpServer.java
+++ b/src/main/java/com/aws/greengrass/localdebugconsole/SimpleHttpServer.java
@@ -51,6 +51,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import software.amazon.awssdk.regions.Region;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -432,6 +433,10 @@ public class SimpleHttpServer extends PluginService implements Authenticator {
                             .replace("%WEBSOCKET_PORT%", Integer.toString(websocketPort))
                             .replace("%USERNAME%", usernameAndPassword.getLeft())
                             .replace("%PASSWORD%", usernameAndPassword.getRight())
+                            .replace("%CHINA_PARTITION%",
+                                    String.valueOf("aws-cn"
+                                            .equals(Region.of(Coerce.toString(deviceConfig.getAWSRegion())).metadata()
+                                                    .partition().id())))
                             .getBytes(StandardCharsets.UTF_8);
                 }
             } catch (Throwable t) {

--- a/src/main/js/dashboard-frontend/public/index.html
+++ b/src/main/js/dashboard-frontend/public/index.html
@@ -37,6 +37,7 @@
       var WEBSOCKET_PORT = %WEBSOCKET_PORT%;
       var USERNAME = "%USERNAME%";
       var PASSWORD = "%PASSWORD%";
+      var CHINA_PARTITION = %CHINA_PARTITION%;
     </script>
     <div id="app"></div>
     <!--

--- a/src/main/js/dashboard-frontend/src/components/details/ConfigEditor.tsx
+++ b/src/main/js/dashboard-frontend/src/components/details/ConfigEditor.tsx
@@ -89,29 +89,32 @@ export class ConfigEditor extends React.Component<
   };
 
   updateFlashbar = (success: boolean, errorMsg?: string) => {
+    const itemID = this.state.flashCnt;
     if (success) {
-      let temp = this.state.flashCnt;
       this.setState({
         flashItems:
           this.state.flashItems.concat([
             {
+              // @ts-ignore
+              num: itemID,
               type: "success",
               content: "Config updated successfully.",
               dismissible: true,
-              onDismiss: () => this.removeItem(temp),
+              onDismiss: () => this.removeItem(itemID),
             },
           ]),
       });
     } else {
-      let temp = this.state.flashCnt;
       this.setState({
         flashItems:
           this.state.flashItems.concat([
             {
+              // @ts-ignore
+              num: itemID,
               type: "error",
               content: `Unable to update config. ${errorMsg}`,
               dismissible: true,
-              onDismiss: () => this.removeItem(temp),
+              onDismiss: () => this.removeItem(itemID),
             },
           ]),
       });

--- a/src/main/js/dashboard-frontend/src/navigation/NavSideBar.tsx
+++ b/src/main/js/dashboard-frontend/src/navigation/NavSideBar.tsx
@@ -20,7 +20,10 @@ const footerItems: SideNavigationProps.Item[] = [
   {
     type: "link",
     text: "Documentation",
-    href: "https://docs.aws.amazon.com/console/greengrass/v2/local",
+    // Get proper docs link depending on if we're using the China partition
+    // @ts-ignore
+    href: window.CHINA_PARTITION ? "https://docs.amazonaws.cn/console/greengrass/v2/local"
+        : "https://docs.aws.amazon.com/console/greengrass/v2/local",
     external: true,
   },
 ];


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes docs link to go to China region docs if we're using the AWS-CN partition. Fixes dismissing flashbar items in the config editor (closes #4).

**Why is this change necessary:**

**How was this change tested:**
Verified that when the region is cn-northwest-1 that it links to the China region docs and the other way around. Verified that flashbar items are now deleted when dismissing them.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
