### PR TITLE
fix: recreate netty event loop on restart

### DIFF
--- a/src/main/java/com/aws/greengrass/localdebugconsole/SimpleHttpServer.java
+++ b/src/main/java/com/aws/greengrass/localdebugconsole/SimpleHttpServer.java
@@ -115,8 +115,8 @@ public class SimpleHttpServer extends PluginService implements Authenticator {
     protected static final String CERT_NAME = "cert";
     protected static final String PRIVATE_KEY_NAME = "private";
     private ChannelFuture channel;
-    private final EventLoopGroup primaryGroup = new NioEventLoopGroup();
-    private final EventLoopGroup secondaryGroup = new NioEventLoopGroup();
+    private EventLoopGroup primaryGroup;
+    private EventLoopGroup secondaryGroup;
     private static final int DEFAULT_HTTP_PORT = 1441;
     private static final int DEFAULT_WEBSOCKET_PORT = 1442;
     private static final boolean DEFAULT_HTTPS_ENABLED = true;
@@ -205,6 +205,8 @@ public class SimpleHttpServer extends PluginService implements Authenticator {
         }
         websocketPort = dashboardServer.getPort();
         logger.atInfo().addKeyValue("port", websocketPort).log("Finished starting websocket server");
+        primaryGroup = new NioEventLoopGroup();
+        secondaryGroup = new NioEventLoopGroup();
         try {
             final ServerBootstrap bootstrap =
                     new ServerBootstrap().group(primaryGroup, secondaryGroup).channel(NioServerSocketChannel.class)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

Fixes #20.

**How was this change tested:**

Ran on mac and verified that without this change we do not run the Netty server on the new hostname.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
