### PR TITLE
fix: allow editing configuration of any component

### DIFF
--- a/src/main/js/dashboard-frontend/src/components/details/ConfigEditor.tsx
+++ b/src/main/js/dashboard-frontend/src/components/details/ConfigEditor.tsx
@@ -9,10 +9,8 @@ import AceEditor from "react-ace";
 import "ace-builds/src-noconflict/mode-yaml";
 import "ace-builds/src-noconflict/theme-solarized_dark";
 import "ace-builds/src-noconflict/theme-iplastic";
-import {ComponentItem} from "../../util/ComponentItem";
 import {SERVER} from "../../index";
 import {APICall, ConfigMessage} from "../../util/CommUtils";
-import {USER_CREATED} from "../../util/constNames";
 import {
   Button,
   Container,
@@ -20,7 +18,6 @@ import {
   FlashbarProps,
   Header,
   Spinner,
-  StatusIndicatorProps,
 } from "@awsui/components-react";
 
 interface ConfigEditorProps {
@@ -28,7 +25,6 @@ interface ConfigEditorProps {
   service: string;
 }
 interface ConfigEditorState {
-  service: ComponentItem | null;
   allowEdit: boolean;
   saving: boolean;
   value: string;
@@ -40,15 +36,6 @@ export class ConfigEditor extends React.Component<
   ConfigEditorState
 > {
   state = {
-    service: {
-      name: "-",
-      version: "-",
-      status: "-",
-      statusIcon: "loading" as StatusIndicatorProps.Type,
-      origin: "User",
-      canStart: false,
-      canStop: false,
-    },
     allowEdit: false,
     saving: false,
     value: "",
@@ -133,10 +120,6 @@ export class ConfigEditor extends React.Component<
         call: APICall.getComponent,
         args: [this.props.service],
       })
-        .then((component) => {
-          this.setState({ service: component });
-          return component;
-        })
         .then((component) =>
           SERVER.sendRequest({
             call: APICall.getConfig,
@@ -162,10 +145,6 @@ export class ConfigEditor extends React.Component<
       call: APICall.getComponent,
       args: [this.props.service],
     })
-      .then((component) => {
-        this.setState({ service: component });
-        return component;
-      })
       .then((component) =>
         SERVER.sendRequest({ call: APICall.getConfig, args: [component.name] })
       )

--- a/src/main/js/dashboard-frontend/src/components/details/ConfigEditor.tsx
+++ b/src/main/js/dashboard-frontend/src/components/details/ConfigEditor.tsx
@@ -172,9 +172,7 @@ export class ConfigEditor extends React.Component<
       .then((config) => {
         if (config.successful) {
           this.setState({ value: config.yaml });
-          if (this.state.service.origin === USER_CREATED) {
-            this.setState({ allowEdit: true });
-          }
+          this.setState({ allowEdit: true });
         } else {
           this.updateFlashbar(false, config.errorMsg);
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

We didn't allow you to edit the configuration for components that weren't considered user created, which was always silly. It is especially annoying when using plugins in the trusted plugin directory because those weren't considered to be user created, so you couldn't change the config.

Without this change you could view and control any service, you just couldn't edit the config using the console. But in order to be truly useful and powerful, we should let you change the configuration too.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
