### PR TITLE
fix: reinitialize keystore if there are any loading problems

### DIFF
--- a/src/main/java/com/aws/greengrass/localdebugconsole/SimpleHttpServer.java
+++ b/src/main/java/com/aws/greengrass/localdebugconsole/SimpleHttpServer.java
@@ -245,14 +245,11 @@ public class SimpleHttpServer extends PluginService implements Authenticator {
                 try (InputStream is = Files.newInputStream(keyStorePath)) {
                     ks.load(is, passphrase);
                 } catch (IOException e) {
-                    // If the password is wrong for whatever reason, delete the existing keystore and
-                    // reinitialize it
-                    if (e.getCause() instanceof UnrecoverableKeyException) {
-                        Files.deleteIfExists(keyStorePath);
-                        initializeKeyStore(ks, passphrase, keyStorePath);
-                    } else {
-                        throw e;
-                    }
+                    logger.warn(
+                            "Failed to load self-signed certificate keystore. Reinitializing keystore automatically",
+                            e);
+                    Files.deleteIfExists(keyStorePath);
+                    initializeKeyStore(ks, passphrase, keyStorePath);
                 }
             } else {
                 initializeKeyStore(ks, passphrase, keyStorePath);

--- a/src/test/java/com/aws/greengrass/localdebugconsole/SimpleHttpServerTest.java
+++ b/src/test/java/com/aws/greengrass/localdebugconsole/SimpleHttpServerTest.java
@@ -14,8 +14,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -23,6 +26,7 @@ import java.util.Map;
 
 import static com.aws.greengrass.localdebugconsole.SimpleHttpServer.DEBUG_PASSWORD_NAMESPACE;
 import static com.aws.greengrass.localdebugconsole.SimpleHttpServer.EXPIRATION_NAMESPACE;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,7 +47,8 @@ class SimpleHttpServerTest {
     }
 
     @Test
-    void GIVEN_server_WHEN_authenticate_THEN_cleans_storage() {
+    void GIVEN_server_WHEN_authenticate_THEN_cleans_storage(ExtensionContext context) throws IOException {
+        ignoreExceptionOfType(context, IOException.class);
         kernel = new Kernel();
         kernel.parseArgs("-r", rootDir.toAbsolutePath().toString());
 
@@ -65,6 +70,11 @@ class SimpleHttpServerTest {
         assertTrue(http.initializeHttps());
         http.getRuntimeConfig().remove(); // remove runtime config so that the password is lost
         kernel.getContext().waitForPublishQueueToClear();
+        assertTrue(http.initializeHttps());
+
+        // Verify that corrupting the keystore is recoverable
+        Files.write(kernel.getNucleusPaths().workPath(SimpleHttpServer.AWS_GREENGRASS_DEBUG_SERVER)
+                .resolve("keystore.jks"), new byte[1024]);
         assertTrue(http.initializeHttps());
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Keystore may fail to load when the file has been corrupted for whatever reason, for example when getting EOFException when reading it. This change expands upon #16 which did the same thing, but for a limited exception class, we now do it for any exception.

**Why is this change necessary:**

**How was this change tested:**
Expanded test scope to include file corruption.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
