### PR TITLE
fix: dependency graph clipping (#33)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
-      - name: Set up Node 12
+      - name: Set up Node 18
         uses: actions/setup-node@v1
         with:
-          node-version: '12'
+          node-version: '18'
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:

--- a/src/main/js/dashboard-frontend/src/components/details/DependencyGraph.tsx
+++ b/src/main/js/dashboard-frontend/src/components/details/DependencyGraph.tsx
@@ -131,7 +131,6 @@ class DependencyGraph extends Component<
     this.d3render(inner, this.g);
     inner.attr("transform", `translate(20, 20)`);
     svg.attr("height", this.g.graph().height + 40);
-    svg.attr("width", this.g.graph().width + 40);
   }
   async componentDidMount() {
     await SERVER.initConnections();
@@ -166,7 +165,7 @@ class DependencyGraph extends Component<
         disableContentPaddings={true}
       >
         <div className="holder">
-          <svg width="100" height="100" ref={this.svg}>
+          <svg height="100" style={{width: "100%"}} ref={this.svg}>
             <g ref={this.innerG} />
           </svg>
         </div>


### PR DESCRIPTION
**Issue #, if available:**
Fixes #33

**Description of changes:**
Set the width of the dependency graph SVG component to 100% of the parent container.
Upgraded node to v18

**Why is this change necessary:**
The existing code was clipping the diagram to the right in certain situations

**How was this change tested:**
Visually by a human

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
