### PR TITLE
fix: display correct sm bandwidth in bytes/sec

### DIFF
--- a/src/main/js/dashboard-frontend/src/__tests__/ComponentTable.test.tsx
+++ b/src/main/js/dashboard-frontend/src/__tests__/ComponentTable.test.tsx
@@ -45,6 +45,7 @@ test("Service item points to the right href", () => {
           .findBodyCell(1, 2)!
           .getElement()!
           .firstElementChild!
+          .firstElementChild!
           .getAttribute("href")
   ).toEqual(SERVICE_ROUTE_HREF_PREFIX + fullRangeList[0].name);
 });

--- a/src/main/js/dashboard-frontend/src/components/StreamManager.tsx
+++ b/src/main/js/dashboard-frontend/src/components/StreamManager.tsx
@@ -254,7 +254,7 @@ function StreamManager() {
                     JVM_ARGS: jvmArgs,
                     LOG_LEVEL: logLevel,
                     STREAM_MANAGER_AUTHENTICATE_CLIENT: streamManagerAuthenticateClient,
-                    STREAM_MANAGER_EXPORTER_MAX_BANDWIDTH: formatBytes(parseInt(streamManagerExporterMaxBandwidth || "0", 10)) + "/s",
+                    STREAM_MANAGER_EXPORTER_MAX_BANDWIDTH: formatBytes(parseInt(streamManagerExporterMaxBandwidth || "0", 10)*1024/8) + "/s",
                     STREAM_MANAGER_EXPORTER_S3_DESTINATION_MULTIPART_UPLOAD_MIN_PART_SIZE_BYTES: formatBytes(parseInt(streamManagerS3UploadMinPart || "0", 10)),
                     STREAM_MANAGER_SERVER_PORT: streamManagerServerPort,
                     STREAM_MANAGER_STORE_ROOT_DIR: streamManagerStoreRootDir,


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-greengrass/aws-greengrass-localdebugconsole/issues/41

**Description of changes:**
Console should display `STREAM_MANAGER_EXPORTER_MAX_BANDWIDTH` provided in `kbps` in bytes/sec (Could be B/KB/MB/GB). Instead, the value is displayed in `mbps`. This PR fixes the conversion so the bandwidth is displayed in bytes/sec. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
